### PR TITLE
Implement command LIST_CHANNELS

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fs"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -43,6 +44,20 @@ func ReadSize(file fs.OsFile) (int64, error) {
 		return 0, err
 	}
 	return fi.Size(), nil
+}
+
+// ReadDirectories returns a list of file names that are children of the given
+// file.
+func ReadDirectories(file fs.OsFile) ([]string, error) {
+	files, err := ioutil.ReadDir(file.Path())
+	if err != nil {
+		return nil, err
+	}
+	var list []string
+	for _, f := range files {
+		list = append(list, f.Name())
+	}
+	return list, nil
 }
 
 func GetExecPath() (string, error) {

--- a/server/client.go
+++ b/server/client.go
@@ -89,7 +89,26 @@ func (c *Client) onMessage(msg Message) {
 	case process.Start:
 		c.start(msg)
 	default:
-		c.error("wrong message state")
+		if msg.Command != nil {
+			c.onCommand(msg.Command)
+		} else {
+			c.error("wrong message state")
+		}
+	}
+}
+
+func (c *Client) onCommand(cmd map[string]string) {
+	req := cmd["REQ"]
+
+	switch req {
+	case "LIST_CHANNELS":
+		err := writeChannels(c.conn)
+		if err != nil {
+			c.error("fail to send list of channels")
+			return
+		}
+	default:
+		c.error("invalid command request")
 	}
 }
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"encoding/json"
+	"fs/files"
 	"fs/process"
 	"net"
 	"time"
@@ -65,4 +66,17 @@ func readMessage(conn net.Conn) (Message, error) {
 	dec := json.NewDecoder(conn)
 	err = dec.Decode(&msg)
 	return msg, err
+}
+
+func writeChannels(conn net.Conn) error {
+	root, err := getFsRootFile()
+	if err != nil {
+		return err
+	}
+	channels, err := files.ReadDirectories(root)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(conn)
+	return enc.Encode(channels)
 }

--- a/server/io.go
+++ b/server/io.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Message struct {
+	Command map[string]string
 	Response
 	process.State
 	Payload

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -185,6 +185,40 @@ func TestDownloadIfNotExists(t *testing.T) {
 	}
 }
 
+func TestChannelList(t *testing.T) {
+	tcpAddr, err := net.ResolveTCPAddr(network, getServerAddress())
+	utils.RequirePassCase(t, err, "Fail to resolve TCP address")
+	conn, err := net.DialTCP(network, nil, tcpAddr)
+	defer conn.Close()
+	utils.RequirePassCase(t, err, "Fail to establish connection")
+
+	// Send command
+	cmd := make(map[string]string)
+	cmd["REQ"] = "LIST_CHANNELS"
+	msg := Message{
+		Command: cmd,
+	}
+	b, err := json.Marshal(msg)
+	_, err = conn.Write(b)
+	utils.RequirePassCase(t, err, "Fail to write command to the server")
+
+	// Receive response
+	var channels []string
+	dec := json.NewDecoder(conn)
+	err = dec.Decode(&channels)
+	if err != nil {
+		return
+	}
+
+	// Check at least has the main, and test channels
+	if !utils.StringSliceContains(channels, "main") {
+		t.Fatal("Channel list does not contain channel: main")
+	}
+	if !utils.StringSliceContains(channels, "test") {
+		t.Fatal("Channel list does not contain channel: test")
+	}
+}
+
 // Tests if the server closes the connection after the read timeout is consumed.
 func TestTcpTimeout(t *testing.T) {
 	if testing.Short() {

--- a/server/storage.go
+++ b/server/storage.go
@@ -13,6 +13,15 @@ const (
 	fsRoot = ".fs"
 )
 
+func getFsRootFile() (fs.OsFile, error) {
+	path, err := files.GetExecPath()
+	if err != nil {
+		return fs.OsFile{}, err
+	}
+	f, _ := fs.NewFileFromString(fsRoot)
+	return f.ToOsFile(path), nil
+}
+
 func getOsFsRoot() (string, error) {
 	path, err := files.GetExecPath()
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -23,3 +23,14 @@ func RequireNoError(e error) {
 		panic(e)
 	}
 }
+
+// StringSliceContains https://play.golang.org/p/Qg_uv_inCek
+// checks if a string is present in a slice
+func StringSliceContains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This allows clients to request commands that are not part of the process FSM.

Commands are read as normal messages usually at state START.