### PR TITLE
Add command LIST_FILES and enhance TCP read timeouts

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -46,9 +46,9 @@ func ReadSize(file fs.OsFile) (int64, error) {
 	return fi.Size(), nil
 }
 
-// ReadDirectories returns a list of file names that are children of the given
+// ReadFileNames returns a list of file names that are children of the given
 // file.
-func ReadDirectories(file fs.OsFile) ([]string, error) {
+func ReadFileNames(file fs.OsFile) ([]string, error) {
 	files, err := ioutil.ReadDir(file.Path())
 	if err != nil {
 		return nil, err

--- a/process/user.go
+++ b/process/user.go
@@ -33,6 +33,10 @@ func (u User) File() fs.OsFile {
 	return u.file
 }
 
+func (u User) Channel() Channel {
+	return u.req.channel
+}
+
 func (u *User) start(payload StartPayload) error {
 	u.req.set(payload)
 	u.count = 0

--- a/server/client.go
+++ b/server/client.go
@@ -107,6 +107,15 @@ func (c *Client) onCommand(cmd map[string]string) {
 			c.error("fail to send list of channels")
 			return
 		}
+	case "LIST_FILES":
+		// TODO channel := c.process.User().Channel()
+		channelName := cmd["CHANNEL"]
+		channel := process.NewChannel(channelName)
+		err := writeFiles(c.conn, channel)
+		if err != nil {
+			c.error("fail to send list of files")
+			return
+		}
 	default:
 		c.error("invalid command request")
 	}

--- a/server/client.go
+++ b/server/client.go
@@ -75,7 +75,7 @@ func (c *Client) next() {
 
 func (c *Client) listenMessage() {
 	log.Println("Listening for client message")
-	msg, err := readMessage(c.conn)
+	msg, err := readMessage(c.conn, longReadTimeOut)
 	if err != nil {
 		c.handleReadError(err, "fail to read message")
 		return
@@ -182,7 +182,7 @@ func (c *Client) onChunkProcessed() {
 
 func (c *Client) listenEof() {
 	log.Println("Listening for EOF")
-	msg, err := readMessage(c.conn)
+	msg, err := readMessage(c.conn, readTimeOut)
 	if err != nil {
 		c.handleReadError(err, "fail to read EOF message")
 		return
@@ -228,7 +228,7 @@ func (c *Client) writeStreamState(payload process.StreamPayload) {
 
 func (c *Client) listenStream() {
 	log.Println("Listening for client STREAM signal")
-	msg, err := readMessage(c.conn)
+	msg, err := readMessage(c.conn, readTimeOut)
 	if err != nil {
 		c.handleReadError(err, "fail to read status STREAM")
 		return

--- a/server/conn.go
+++ b/server/conn.go
@@ -73,7 +73,7 @@ func writeChannels(conn net.Conn) error {
 	if err != nil {
 		return err
 	}
-	channels, err := files.ReadDirectories(root)
+	channels, err := files.ReadFileNames(root)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func writeFiles(conn net.Conn, channel process.Channel) error {
 	}
 	dir, _ := channel.File()
 	channelFile := dir.ToOsFile(root.Path())
-	fileList, err := files.ReadDirectories(channelFile)
+	fileList, err := files.ReadFileNames(channelFile)
 	if err != nil {
 		return err
 	}

--- a/server/conn.go
+++ b/server/conn.go
@@ -18,6 +18,10 @@ const (
 )
 
 func readChunk(conn net.Conn) ([]byte, error) {
+	err := conn.SetReadDeadline(time.Now().Add(readTimeOut))
+	if err != nil {
+		return nil, err
+	}
 	b := make([]byte, bufSize)
 	n, err := conn.Read(b)
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	readTimeOut = 20 * time.Second
+	readTimeOut     = 20 * time.Second
+	longReadTimeOut = 20 * time.Minute
 )
 
 func readChunk(conn net.Conn) ([]byte, error) {
@@ -57,8 +58,8 @@ func writeMessage(msg Message, conn net.Conn) error {
 	return enc.Encode(msg)
 }
 
-func readMessage(conn net.Conn) (Message, error) {
-	err := conn.SetReadDeadline(time.Now().Add(readTimeOut))
+func readMessage(conn net.Conn, timeout time.Duration) (Message, error) {
+	err := conn.SetReadDeadline(time.Now().Add(timeout))
 	if err != nil {
 		return Message{}, err
 	}

--- a/server/conn.go
+++ b/server/conn.go
@@ -80,3 +80,18 @@ func writeChannels(conn net.Conn) error {
 	enc := json.NewEncoder(conn)
 	return enc.Encode(channels)
 }
+
+func writeFiles(conn net.Conn, channel process.Channel) error {
+	root, err := getFsRootFile()
+	if err != nil {
+		return err
+	}
+	dir, _ := channel.File()
+	channelFile := dir.ToOsFile(root.Path())
+	fileList, err := files.ReadDirectories(channelFile)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(conn)
+	return enc.Encode(fileList)
+}

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -219,6 +219,36 @@ func TestChannelList(t *testing.T) {
 	}
 }
 
+func TestFileList(t *testing.T) {
+	tcpAddr, err := net.ResolveTCPAddr(network, getServerAddress())
+	utils.RequirePassCase(t, err, "Fail to resolve TCP address")
+	conn, err := net.DialTCP(network, nil, tcpAddr)
+	defer conn.Close()
+	utils.RequirePassCase(t, err, "Fail to establish connection")
+
+	// Send command
+	cmd := make(map[string]string)
+	cmd["REQ"] = "LIST_FILES"
+	cmd["CHANNEL"] = testChannel
+	msg := Message{
+		Command: cmd,
+	}
+	b, err := json.Marshal(msg)
+	_, err = conn.Write(b)
+	utils.RequirePassCase(t, err, "Fail to write command to the server")
+
+	// Receive response
+	var fileList []string
+	dec := json.NewDecoder(conn)
+	err = dec.Decode(&fileList)
+	if err != nil {
+		return
+	}
+
+	// Check
+	log.Println("Files on channel test:", fileList)
+}
+
 // Tests if the server closes the connection after the read timeout is consumed.
 func TestTcpTimeout(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
This adds the command LIST_FILES to the server, and adds a better configuration for read timeouts that will allow a client to stay for long at state START, while timeouts are still short for process operations like status DATA for reading chunks for instance.