### PR TITLE
Implement a concurrent read model

### DIFF
--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
@@ -1,0 +1,6 @@
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/tobiasbriones/ep-tcp-file-system
+
+package engineer.mathsoftware.ep.tcpfs
+

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
@@ -4,8 +4,16 @@
 
 package engineer.mathsoftware.ep.tcpfs
 
+import org.json.JSONObject
+
 enum class DataType {
     MESSAGE,
     ARRAY,
     RAW
+}
+
+// It parses this data as a JSONObject assuming this is a generic server
+// response message.
+fun ByteArray.parseMessage(): JSONObject {
+    return JSONObject(String(this))
 }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
@@ -4,6 +4,8 @@
 
 package engineer.mathsoftware.ep.tcpfs
 
+import engineer.mathsoftware.ep.tcpfs.DataType.*
+import org.json.JSONArray
 import org.json.JSONObject
 
 enum class DataType {
@@ -17,3 +19,11 @@ enum class DataType {
 fun ByteArray.parseMessage(): JSONObject {
     return JSONObject(String(this))
 }
+
+
+// It parses this data as a JSONArray assuming this is a generic server
+// response array.
+fun ByteArray.parseArray(): JSONArray {
+    return JSONArray(String(this))
+}
+

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
@@ -27,3 +27,18 @@ fun ByteArray.parseArray(): JSONArray {
     return JSONArray(String(this))
 }
 
+// This is a low-level response parsing, a high-level construct like states
+// must be used to understand the actual meaning of the server.
+//
+// For example: It can be a response that is a data chunk for a small JSON
+// text file, but this can be interpreted as a server message or as a data
+// chunk, it depends on the machine state.
+fun ByteArray.type(): DataType {
+    val str = String(this)
+    if (str.isEmpty()) return RAW
+    return when (str[0]) {
+        '{'  -> MESSAGE
+        '['  -> ARRAY
+        else -> RAW
+    }
+}

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
@@ -4,3 +4,8 @@
 
 package engineer.mathsoftware.ep.tcpfs
 
+enum class DataType {
+    MESSAGE,
+    ARRAY,
+    RAW
+}

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ByteArrays.kt
@@ -10,7 +10,7 @@ import org.json.JSONObject
 
 sealed interface DataType {
     data class Message(val value: JSONObject) : DataType
-    data class Array(val value: JSONArray) : DataType
+    data class Array(val value: JSONArray) : DataType // TODO Not required now
     data class Raw(val value: ByteArray) : DataType
 }
 

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Client.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Client.kt
@@ -19,15 +19,6 @@ enum class Action {
     DOWNLOAD
 }
 
-enum class State {
-    START,
-    DATA,
-    STREAM,
-    EOF,
-    DONE,
-    ERROR
-}
-
 const val PORT: Int = 8080
 
 data class Input(
@@ -203,7 +194,7 @@ class Client(
     private fun getStartMessage(action: Action, size: Int = 0): JSONObject {
         val payload = getStartPayload(action, size)
         val ser = JSONObject()
-        ser.put("State", State.START)
+        ser.put("State", Process.START)
         ser.put("Data", payload)
         return ser
     }
@@ -231,14 +222,14 @@ class Client(
 
     private fun getEofMessage(): JSONObject {
         val ser = JSONObject()
-        ser.put("State", State.EOF)
+        ser.put("State", Process.EOF)
         ser.put("Data", null)
         return ser
     }
 
     private fun getStreamMessage(): JSONObject {
         val ser = JSONObject()
-        ser.put("State", State.STREAM)
+        ser.put("State", Process.STREAM)
         ser.put("Data", null)
         return ser
     }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Client.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Client.kt
@@ -96,7 +96,7 @@ class Client(
         // TODO Arrays are used for the list of clients, I must make this
         // type safe by embedding it into a message object
         withContext(Dispatchers.Main) {
-            val channels = parseCommandListChannels(array)
+            val channels = array.toStringList()
             input.onChannelList?.invoke(channels)
         }
     }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Client.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Client.kt
@@ -20,6 +20,7 @@ enum class Action {
 }
 
 // TODO temp. response values, server is still in beta
+const val UPDATE = 2
 const val OK = 3
 
 const val PORT: Int = 8080
@@ -28,6 +29,7 @@ data class Input(
     val onChannelList: ((channels: List<String>) -> Unit)? = null,
     val onFileList: ((channels: List<String>) -> Unit)? = null,
     val onCID: ((cid: Int) -> Unit)? = null,
+    val onUpdate: (() -> Unit)? = null,
 )
 
 class Client(
@@ -95,7 +97,12 @@ class Client(
 
     private suspend fun onMessage(msg: JSONObject) {
         val response = msg.getInt("Response")
-println(msg)
+
+        println(msg)
+        if (response == UPDATE) {
+            input.onUpdate?.invoke()
+            return
+        }
         if (response != OK) {
             // TODO handle
             println("ERROR: Response not OK")

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Client.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Client.kt
@@ -4,6 +4,7 @@
 
 package engineer.mathsoftware.ep.tcpfs
 
+import android.net.Uri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -179,45 +180,10 @@ class Client(
         }
     }
 
-    suspend fun download(l: (progress: Float) -> Unit): ByteArray {
-        return withContext(Dispatchers.IO) {
-            try {
-                // var msg = getStartMessage(Action.DOWNLOAD)
-                // conn.writeMessage(msg)
-                // println("Start message sent")
-                //
-                // var res = conn.readMessage()
-                // var payload = conn.readData(res)
-                // val size = payload["Size"].toString()
-                //     .toInt()
-                // println("Payload: $payload")
-                //
-                // msg = getStreamMessage()
-                // conn.writeMessage(msg)
-                //
-                // val array = conn.downstream(size, l)
-                //
-                // if (array.size != size) {
-                //     println("ERROR: Overflow")
-                // }
-                //
-                // msg = getEofMessage()
-                // conn.writeMessage(msg)
-                //
-                // val done = conn.readMessage()
-                // println("State: ${done["State"]}")
-                //
-                // array
-                ByteArray(0)
-            }
-            catch (e: JSONException) {
-                println("ERROR: fail to read server response: " + e.message)
-                ByteArray(0)
-            }
-            catch (e: NoSuchElementException) {
-                println("Connection closed: $e.message")
-                ByteArray(0)
-            }
+    suspend fun download(uri: Uri) {
+        withContext(Dispatchers.IO) {
+            val payload = StartPayload(file, channel)
+            state.startDownload(payload, uri)
         }
     }
 }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientFragment.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientFragment.kt
@@ -45,7 +45,7 @@ class ClientFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        output = ClientOutput(binding.infoText)
+        output = ClientOutput(binding.infoText) { requireContext().contentResolver }
         filesAdapter = FilesAdapter(files) { download(it) }
         initFileList()
         binding.buttonUpload.setOnClickListener {
@@ -210,28 +210,13 @@ class ClientFragment : Fragment() {
     private fun startDownload(uri: Uri) {
         lifecycleScope.launch {
             try {
-                var chunksTotal = 0
-                val array = client.download {
-                    val percentage = it * 100
-                    binding.infoText.text = "Downloading $percentage%"
-                    chunksTotal++
-                }
-                write(requireContext().contentResolver, uri, array)
-                handleFileDownloaded(chunksTotal)
-                println("Downloaded ${array.size}")
+                client.download(uri)
             }
-            catch (e: SocketException) {
+            catch (e: Exception) {
                 println("ERROR: ${e.message}")
                 handleConnectionFailed()
             }
         }
-    }
-
-    private fun handleFileDownloaded(chunksTotal: Int) {
-        binding.infoText.text = """
-            File downloaded: ${client.file} | $chunksTotal chunks received
-        """.trimIndent()
-        readFiles()
     }
 
     private fun chooseDownloadFolder() {

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientFragment.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientFragment.kt
@@ -91,9 +91,10 @@ class ClientFragment : Fragment() {
 
     private fun connect() {
         val host = Config(requireActivity()).getServerHost() ?: ""
+        val input = Input(null)
 
         lifecycleScope.launch {
-            val c = Client.newInstance(host)
+            val c = Client.newInstance(host, input)
 
             if (c == null) {
                 handleConnectionFailed()

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientFragment.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientFragment.kt
@@ -91,7 +91,7 @@ class ClientFragment : Fragment() {
 
     private fun connect() {
         val host = Config(requireActivity()).getServerHost() ?: ""
-        val input = Input(null, ::onFileList, ::onCID)
+        val input = Input(null, ::onFileList, ::onCID, ::onUpdate)
 
         lifecycleScope.launch {
             val c = Client.newInstance(host, input)
@@ -153,6 +153,11 @@ class ClientFragment : Fragment() {
         binding.infoText.text = "Connected"
     }
 
+    private fun onUpdate() {
+        println("Update!")
+        readFiles()
+    }
+
     private fun disconnect() {
         if (!this::client.isInitialized) return
         lifecycleScope.launch {
@@ -163,7 +168,6 @@ class ClientFragment : Fragment() {
     private fun readFiles() {
         if (!this::client.isInitialized) return
         lifecycleScope.launch {
-            println("requesting files")
             client.readFiles()
         }
     }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientOutput.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientOutput.kt
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/tobiasbriones/ep-tcp-file-system
+
+package engineer.mathsoftware.ep.tcpfs
+
+import android.widget.TextView
+
+class ClientOutput(private val info: TextView) : Output {
+    override fun updateUploadProgress(progress: Float) {
+        val percentage = progress * 100
+        info.text = "Uploading $percentage%"
+    }
+
+    override fun uploadDone(file: String, chunksTotal: Int) {
+        info.text = """
+            File uploaded: ${file} | $chunksTotal chunks sent
+        """.trimIndent()
+    }
+}

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientOutput.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/ClientOutput.kt
@@ -4,9 +4,14 @@
 
 package engineer.mathsoftware.ep.tcpfs
 
+import android.content.ContentResolver
+import android.net.Uri
 import android.widget.TextView
 
-class ClientOutput(private val info: TextView) : Output {
+class ClientOutput(
+    private val info: TextView,
+    private val getContentResolver: () -> ContentResolver
+) : Output {
     override fun updateUploadProgress(progress: Float) {
         val percentage = progress * 100
         info.text = "Uploading $percentage%"
@@ -16,5 +21,23 @@ class ClientOutput(private val info: TextView) : Output {
         info.text = """
             File uploaded: ${file} | $chunksTotal chunks sent
         """.trimIndent()
+    }
+
+    override fun updateDownloadProgress(progress: Float) {
+        val percentage = progress * 100
+        info.text = "Downloading $percentage%"
+    }
+
+    override fun downloadDone(
+        data: ByteArray,
+        uri: Uri,
+        file: String,
+        chunksTotal: Int
+    ) {
+        write(getContentResolver(), uri, data)
+        info.text = """
+            File downloaded: ${file} | $chunksTotal chunks received
+        """.trimIndent()
+        println("Downloaded ${data.size}")
     }
 }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Conn.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Conn.kt
@@ -35,7 +35,7 @@ class Conn(private val socket: Socket) {
         )
     }
 
-    fun readFiles(channel: String): List<String> {
+    fun writeCommandListFiles(channel: String) {
         val os = socket.getOutputStream()
         val msg = JSONObject()
         val cmd = JSONObject()
@@ -48,18 +48,9 @@ class Conn(private val socket: Socket) {
             msg.toString()
                 .toByteArray()
         )
-        val res = reader.readLine()
-        if (res == null || res == "null") {
-            return ArrayList()
-        }
-        val jsonArray = JSONArray(res)
-        val channels = Array(jsonArray.length()) {
-            jsonArray.getString(it)
-        }
-        return channels.toList()
     }
 
-    fun readCID(): Int {
+    fun writeCommandCID() {
         val os = socket.getOutputStream()
         val msg = JSONObject()
         val cmd = JSONObject()
@@ -71,8 +62,6 @@ class Conn(private val socket: Socket) {
             msg.toString()
                 .toByteArray()
         )
-        val res = reader.readLine()
-        return Integer.parseInt(res)
     }
 
     suspend fun stream(bytes: ByteArray, l: (progress: Float) -> Unit) {
@@ -142,7 +131,9 @@ class Conn(private val socket: Socket) {
     }
 
     fun readNext(): ByteArray {
-        val buff = ByteArray(SERVER_BUF_SIZE)
+        // TODO give a big enough buffer to avoid while loop for now and
+        //  message end char
+        val buff = ByteArray(SERVER_BUF_SIZE*4)
         socket.getInputStream()
             .read(buff)
         return buff

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Conn.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Conn.kt
@@ -149,14 +149,6 @@ class Conn(private val socket: Socket) {
     }
 }
 
-fun parseCommandListChannels(array: JSONArray): List<String> {
-    // TODO must be a message with the array embedded
-    val channels = Array(array.length()) {
-        array.getString(it)
-    }
-    return channels.toList()
-}
-
 private fun getPercentage(count: Int, size: Int): Float {
     return if (count >= size) 1.0f
     else count.toFloat() / size.toFloat()

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Conn.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Conn.kt
@@ -64,10 +64,11 @@ class Conn(private val socket: Socket) {
         )
     }
 
-    suspend fun stream(bytes: ByteArray, l: (progress: Float) -> Unit) {
+    suspend fun stream(bytes: ByteArray, l: (progress: Float) -> Unit): Int {
         val size = bytes.size
         val os = socket.getOutputStream()
         var count = 0
+        var chunksTotal = 0
 
         while (count < size) {
             var end = count + SERVER_BUF_SIZE - 1
@@ -77,10 +78,12 @@ class Conn(private val socket: Socket) {
             )
             os.write(chunk)
             count += SERVER_BUF_SIZE
+            chunksTotal++
             withContext(Dispatchers.Main) {
                 l(getPercentage(count, size))
             }
         }
+        return chunksTotal
     }
 
     fun readState(): String {

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Conn.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/Conn.kt
@@ -21,7 +21,7 @@ class Conn(private val socket: Socket) {
         )
     )
 
-    fun readChannels(): List<String> {
+    fun writeCommandListChannels() {
         val os = socket.getOutputStream()
         val msg = JSONObject()
         val cmd = JSONObject()
@@ -33,12 +33,6 @@ class Conn(private val socket: Socket) {
             msg.toString()
                 .toByteArray()
         )
-        val res = reader.readLine()
-        val jsonArray = JSONArray(res)
-        val channels = Array(jsonArray.length()) {
-            jsonArray.getString(it)
-        }
-        return channels.toList()
     }
 
     fun readFiles(channel: String): List<String> {
@@ -146,6 +140,21 @@ class Conn(private val socket: Socket) {
             .read(chunk)
         return chunk.sliceArray(IntRange(0, n - 1))
     }
+
+    fun readNext(): ByteArray {
+        val buff = ByteArray(SERVER_BUF_SIZE)
+        socket.getInputStream()
+            .read(buff)
+        return buff
+    }
+}
+
+fun parseCommandListChannels(array: JSONArray): List<String> {
+    // TODO must be a message with the array embedded
+    val channels = Array(array.length()) {
+        array.getString(it)
+    }
+    return channels.toList()
 }
 
 private fun getPercentage(count: Int, size: Int): Float {

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/DownloadBuffer.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/DownloadBuffer.kt
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/tobiasbriones/ep-tcp-file-system
+
+package engineer.mathsoftware.ep.tcpfs
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class DownloadBuffer(
+    private val size: Int,
+    private val l: (progress: Float) -> Unit
+) {
+    var data = ByteArray(0)
+    var count = 0
+    var chunksTotal = 0
+
+    fun isDone() = count == size
+
+    fun isOverflowed() = count > size
+
+    suspend fun append(chunk: ByteArray) {
+        data += chunk
+        count += chunk.size
+        chunksTotal++
+        withContext(Dispatchers.Main) {
+            l(getPercentage(count, size))
+        }
+    }
+}

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/JSONArrays.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/JSONArrays.kt
@@ -1,0 +1,14 @@
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/tobiasbriones/ep-tcp-file-system
+
+package engineer.mathsoftware.ep.tcpfs
+
+import org.json.JSONArray
+
+fun JSONArray.toStringList(): List<String> {
+    val values = Array(length()) {
+        getString(it)
+    }
+    return values.toList()
+}

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/MainFragment.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/MainFragment.kt
@@ -65,7 +65,7 @@ class MainFragment : Fragment() {
         val input = Input(this::onChannelList)
 
         lifecycleScope.launch {
-            val c = Client.newInstance(host, input)
+            val c = Client.newInstance(host, input, VoidOutput())
 
             if (c == null) {
                 handleConnectionFailed()

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/MainFragment.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/MainFragment.kt
@@ -62,8 +62,10 @@ class MainFragment : Fragment() {
 
     private fun connect() {
         val host = Config(requireActivity()).getServerHost() ?: ""
+        val input = Input(this::onChannelList)
+
         lifecycleScope.launch {
-            val c = Client.newInstance(host)
+            val c = Client.newInstance(host, input)
 
             if (c == null) {
                 handleConnectionFailed()
@@ -79,12 +81,23 @@ class MainFragment : Fragment() {
     private suspend fun handleConnected() {
         if (!this::client.isInitialized) return
         try {
-            val channels = client.readChannels()
-            loadChannels(channels)
+            listen()
+            client.readChannels()
         }
-        catch (e: JSONException) {
+        catch (e: Exception) {
+            handleConnectionFailed()
             println(e.message)
         }
+    }
+
+    private fun listen() {
+        lifecycleScope.launch {
+            client.listen()
+        }
+    }
+
+    private fun onChannelList(channels: List<String>) {
+        loadChannels(channels)
     }
 
     private fun subscribe(channel: String) {

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
@@ -5,6 +5,8 @@
 package engineer.mathsoftware.ep.tcpfs
 
 import engineer.mathsoftware.ep.tcpfs.Process.*
+import org.json.JSONArray
+import org.json.JSONObject
 
 enum class Process {
     START,
@@ -15,17 +17,140 @@ enum class Process {
     ERROR
 }
 
-class State {
+data class StartPayload(
+    val file: String,
+    val channel: String,
+    val size: Int = 0
+)
+
+interface Output {
+    fun updateUploadProgress(progress: Float)
+    fun uploadDone(file: String, chunksTotal: Int)
+}
+
+class State(private val conn: Conn, private val output: Output) {
     private var state = START
+    private var action = Action.UPLOAD
+    private var file = ""
+    private var data = ByteArray(0)
+    private var chunksTotal = 0
 
     fun isInProgress() = !isOnHold()
 
     fun isOnHold() = when (state) {
-        START, DONE, ERROR -> true
-        else               -> false
+        START, ERROR -> true
+        else         -> false
     }
 
-    fun parse(data: ByteArray) {
-
+    suspend fun parse(data: ByteArray) {
+        when (state) {
+            DATA -> readStateData(data.parseMessage())
+            EOF  -> readStateEOF(data.parseMessage())
+            DONE -> readStateDone(data.parseMessage())
+        }
     }
+
+    fun startUpload(bytes: ByteArray, p: StartPayload) {
+        if (isInProgress()) {
+            return
+        }
+        var msg = getStartMessage(Action.UPLOAD, p)
+        conn.writeMessage(msg)
+        action = Action.UPLOAD
+        file = p.file
+        data = bytes
+        chunksTotal = 0
+        state = DATA
+        println("Start message sent")
+    }
+
+    private suspend fun readStateData(msg: JSONObject) {
+        if (msg["State"] != "DATA") {
+            state = ERROR
+            print("ERROR: Fail to read state DATA: $msg")
+            return
+        }
+        println("STATE=DATA confirmed")
+        sendData()
+    }
+
+    private suspend fun sendData() {
+        chunksTotal = conn.stream(data, output::updateUploadProgress)
+        state = EOF
+    }
+
+    private fun readStateEOF(msg: JSONObject) {
+        if (msg["State"] != "EOF") {
+            state = ERROR
+            print("ERROR: Fail to read state EOF: $msg")
+            return
+        }
+        println("STATE=EOF confirmed")
+        sendEof()
+    }
+
+    private fun sendEof() {
+        val msg = getEofMessage()
+        conn.writeMessage(msg)
+        state = DONE
+        println("EOF message sent")
+    }
+
+    private fun readStateDone(msg: JSONObject) {
+        if (msg["State"] != "DONE") {
+            state = ERROR
+            print("ERROR: Fail to read state EOF: $msg")
+            return
+        }
+        done()
+    }
+
+    private fun done() {
+        state = START
+        output.uploadDone(file, chunksTotal)
+        println("Done!")
+    }
+}
+
+private fun getStartMessage(action: Action, p: StartPayload): JSONObject {
+    val payload = getStartPayload(action, p)
+    val ser = JSONObject()
+    ser.put("State", START)
+    ser.put("Data", payload)
+    return ser
+}
+
+private fun getStartPayload(action: Action, p: StartPayload): JSONArray {
+    val payload = """
+            {
+                "Action": ${action.ordinal},
+                "Value": "${p.file}",
+                "Size": ${p.size},
+                "Channel": {
+                    "Name": "${p.channel}"
+                }
+            }
+        """.trimIndent()
+    var json = JSONObject(payload)
+    val arr = JSONArray()
+    json.toString()
+        .toByteArray()
+        .forEach {
+            arr.put(it)
+        }
+    return arr
+}
+
+private fun getEofMessage(): JSONObject {
+    val ser = JSONObject()
+    ser.put("State", EOF)
+    ser.put("Data", null)
+    return ser
+}
+
+private fun getStreamMessage(): JSONObject {
+    val ser = JSONObject()
+    ser.put("State", STREAM)
+    ser.put("Data", null)
+    return ser
 }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
@@ -24,4 +24,8 @@ class State {
         START, DONE, ERROR -> true
         else               -> false
     }
+
+    fun parse(data: ByteArray) {
+
+    }
 }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/tobiasbriones/ep-tcp-file-system
+
+package engineer.mathsoftware.ep.tcpfs
+
+enum class Process {
+    START,
+    DATA,
+    STREAM,
+    EOF,
+    DONE,
+    ERROR
+}
+
+class State {
+
+}

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
@@ -158,7 +158,7 @@ class State(private val conn: Conn, private val output: Output) {
     private fun readStateDone(msg: JSONObject) {
         if (msg["State"] != "DONE") {
             state = ERROR
-            print("ERROR: Fail to read state EOF: $msg")
+            print("ERROR: Fail to read state DONE: $msg")
             return
         }
         done()

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/State.kt
@@ -4,6 +4,8 @@
 
 package engineer.mathsoftware.ep.tcpfs
 
+import engineer.mathsoftware.ep.tcpfs.Process.*
+
 enum class Process {
     START,
     DATA,
@@ -14,5 +16,12 @@ enum class Process {
 }
 
 class State {
+    private var state = START
 
+    fun isInProgress() = !isOnHold()
+
+    fun isOnHold() = when (state) {
+        START, DONE, ERROR -> true
+        else               -> false
+    }
 }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/VoidOutput.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/VoidOutput.kt
@@ -4,7 +4,7 @@
 
 package engineer.mathsoftware.ep.tcpfs
 
-import android.widget.TextView
+import android.net.Uri
 
 class VoidOutput() : Output {
     override fun updateUploadProgress(progress: Float) {
@@ -12,6 +12,19 @@ class VoidOutput() : Output {
     }
 
     override fun uploadDone(file: String, chunksTotal: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateDownloadProgress(progress: Float) {
+        TODO("Not yet implemented")
+    }
+
+    override fun downloadDone(
+        data: ByteArray,
+        uri: Uri,
+        file: String,
+        chunksTotal: Int
+    ) {
         TODO("Not yet implemented")
     }
 }

--- a/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/VoidOutput.kt
+++ b/client/app/src/main/java/engineer/mathsoftware/ep/tcpfs/VoidOutput.kt
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/tobiasbriones/ep-tcp-file-system
+
+package engineer.mathsoftware.ep.tcpfs
+
+import android.widget.TextView
+
+class VoidOutput() : Output {
+    override fun updateUploadProgress(progress: Float) {
+        TODO("Not yet implemented")
+    }
+
+    override fun uploadDone(file: String, chunksTotal: Int) {
+        TODO("Not yet implemented")
+    }
+}

--- a/server/command.go
+++ b/server/command.go
@@ -13,6 +13,16 @@ import (
 	"strconv"
 )
 
+type req string
+
+const (
+	CreateChannel  req = "CREATE_CHANNEL"
+	ListChannels   req = "LIST_CHANNELS"
+	ListFiles      req = "LIST_FILES"
+	CID            req = "CID"
+	ConnectedUsers req = "CONNECTED_USERS"
+)
+
 type command struct {
 	conn net.Conn
 	commandClient
@@ -23,10 +33,10 @@ func newCommand(conn net.Conn, client commandClient) command {
 }
 
 func (c command) execute(cmd map[string]string) error {
-	req := cmd["REQ"]
+	req := req(cmd["REQ"])
 
 	switch req {
-	case "CREATE_CHANNEL":
+	case CreateChannel:
 		channelName := cmd["CHANNEL"]
 		file, err := getFsRootFile()
 		if err != nil {
@@ -42,12 +52,12 @@ func (c command) execute(cmd map[string]string) error {
 			log.Println(err)
 			return errors.New("server error")
 		}
-	case "LIST_CHANNELS":
+	case ListChannels:
 		err := writeChannels(c.conn)
 		if err != nil {
 			return errors.New("fail to send list of channels")
 		}
-	case "LIST_FILES":
+	case ListFiles:
 		// TODO channel := c.process.User().Channel()
 		channelName := cmd["CHANNEL"]
 		channel := process.NewChannel(channelName)
@@ -55,12 +65,12 @@ func (c command) execute(cmd map[string]string) error {
 		if err != nil {
 			return errors.New("fail to send list of files")
 		}
-	case "CID":
+	case CID:
 		_, err := c.conn.Write([]byte(strconv.Itoa(int(c.cid())) + "\n"))
 		if err != nil {
 			return errors.New("fail to send client ID")
 		}
-	case "CONNECTED_USERS":
+	case ConnectedUsers:
 		// Send a signal to send the list of users to this client
 		c.requestClientList()
 	default:

--- a/server/command.go
+++ b/server/command.go
@@ -37,44 +37,64 @@ func (c command) execute(cmd map[string]string) error {
 
 	switch req {
 	case CreateChannel:
-		channelName := cmd["CHANNEL"]
-		file, err := getFsRootFile()
-		if err != nil {
-			log.Println(err)
-			return errors.New("server error")
-		}
-		err = file.Append(channelName)
-		if err != nil {
-			return errors.New("invalid channel")
-		}
-		err = files.CreateIfNotExists(file)
-		if err != nil {
-			log.Println(err)
-			return errors.New("server error")
-		}
+		return c.createChannel(cmd)
 	case ListChannels:
-		err := writeChannels(c.conn)
-		if err != nil {
-			return errors.New("fail to send list of channels")
-		}
+		return c.listChannels()
 	case ListFiles:
-		// TODO channel := c.process.User().Channel()
-		channelName := cmd["CHANNEL"]
-		channel := process.NewChannel(channelName)
-		err := writeFiles(c.conn, channel)
-		if err != nil {
-			return errors.New("fail to send list of files")
-		}
+		return c.listFiles(cmd)
 	case CID:
-		_, err := c.conn.Write([]byte(strconv.Itoa(int(c.cid())) + "\n"))
-		if err != nil {
-			return errors.New("fail to send client ID")
-		}
+		return c.sendCID()
 	case ConnectedUsers:
 		// Send a signal to send the list of users to this client
 		c.requestClientList()
 	default:
 		return errors.New("invalid command request")
+	}
+	return nil
+}
+
+func (c command) createChannel(cmd map[string]string) error {
+	channelName := cmd["CHANNEL"]
+	file, err := getFsRootFile()
+	if err != nil {
+		log.Println(err)
+		return errors.New("server error")
+	}
+	err = file.Append(channelName)
+	if err != nil {
+		return errors.New("invalid channel")
+	}
+	err = files.CreateIfNotExists(file)
+	if err != nil {
+		log.Println(err)
+		return errors.New("server error")
+	}
+	return nil
+}
+
+func (c command) listChannels() error {
+	err := writeChannels(c.conn)
+	if err != nil {
+		return errors.New("fail to send list of channels")
+	}
+	return nil
+}
+
+func (c command) listFiles(cmd map[string]string) error {
+	// TODO channel := c.process.User().Channel()
+	channelName := cmd["CHANNEL"]
+	channel := process.NewChannel(channelName)
+	err := writeFiles(c.conn, channel)
+	if err != nil {
+		return errors.New("fail to send list of files")
+	}
+	return nil
+}
+
+func (c command) sendCID() error {
+	_, err := c.conn.Write([]byte(strconv.Itoa(int(c.cid())) + "\n"))
+	if err != nil {
+		return errors.New("fail to send client ID")
 	}
 	return nil
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"encoding/json"
-	"fs/files"
 	"fs/process"
 	"net"
 	"time"
@@ -71,32 +70,4 @@ func readMessage(conn net.Conn, timeout time.Duration) (Message, error) {
 	dec := json.NewDecoder(conn)
 	err = dec.Decode(&msg)
 	return msg, err
-}
-
-func writeChannels(conn net.Conn) error {
-	root, err := getFsRootFile()
-	if err != nil {
-		return err
-	}
-	channels, err := files.ReadFileNames(root)
-	if err != nil {
-		return err
-	}
-	enc := json.NewEncoder(conn)
-	return enc.Encode(channels)
-}
-
-func writeFiles(conn net.Conn, channel process.Channel) error {
-	root, err := getFsRootFile()
-	if err != nil {
-		return err
-	}
-	dir, _ := channel.File()
-	channelFile := dir.ToOsFile(root.Path())
-	fileList, err := files.ReadFileNames(channelFile)
-	if err != nil {
-		return err
-	}
-	enc := json.NewEncoder(conn)
-	return enc.Encode(fileList)
 }


### PR DESCRIPTION
Reads and Writes were blocking calls before and that didn't allow to receive messages from the server asynchronously.

A separate thread is running now to centralize all reads and then route them according to the process state.

This also adds the feature of updating the list of files when a change occurred in the server.